### PR TITLE
Issue #20 Create Jenkins job to build minishift docs

### DIFF
--- a/minishift-ci-index.yaml
+++ b/minishift-ci-index.yaml
@@ -114,6 +114,7 @@
 - project:
     name: minishift
     jobs:
+      # Master builds
       - '{git_repo}':
           git_repo: minishift
           ci_project: '{name}'
@@ -129,7 +130,7 @@
           ci_project: '{name}'
           ci_cmd: '/bin/bash centos_ci.sh'
           timeout: '30m'
-
+      # PR builds
       - '{git_repo}-pr':
           git_repo: minishift
           ci_project: '{name}'
@@ -145,3 +146,9 @@
           ci_project: '{name}'
           ci_cmd: '/bin/bash centos_ci.sh'
           timeout: '30m'
+      # Docs builds
+      - '{git_repo}-docs':
+          git_repo: minishift
+          ci_project: '{name}'
+          ci_cmd: '/bin/bash centos_ci.sh'
+          timeout: '20m'


### PR DESCRIPTION
Fix #20 .

@hferentschik Let me know if you have any suggestoin for job name `centos_ci_docs.sh`. 