### PR TITLE
Issue #35 Setup build notification for nightly job

### DIFF
--- a/minishift-ci-index.yaml
+++ b/minishift-ci-index.yaml
@@ -246,6 +246,14 @@
                 - master
     triggers:
         - timed: '0 0 * * *'
+    publishers:
+        - email-ext:
+            recipients: lmohanty@redhat.com, gbraad@redhat.com, hferents@redhat.com, prkumar@redhat.com, bgurung@redhat.com, agajdosi@redhat.com, arout@redhat.com
+            content-type: text
+            subject: Minishift nightly build ${BUILD_NUMBER}
+            body: "The build has finished. Build URL: ${BUILD_URL}"
+            failure: true
+            success: true
     builders:
         - shell: |
               # testing out the cico client


### PR DESCRIPTION
Fix #35

@LalatenduMohanty @hferentschik , this PR will setup email notification of nightly build and send email on each failure/success to Minishift mailing list.

*NOTE*: We can remove sending email notification on build success later. To test the build notification I am sending on success at the moment.

Other options we can set are listed here https://docs.openstack.org/infra/jenkins-job-builder/publishers.html#publishers.email-ext