### PR TITLE
Skip the braces in passing to the email-ext publisher 

### DIFF
--- a/minishift-ci-index.yaml
+++ b/minishift-ci-index.yaml
@@ -250,8 +250,8 @@
         - email-ext:
             recipients: lmohanty@redhat.com, gbraad@redhat.com, hferents@redhat.com, prkumar@redhat.com, bgurung@redhat.com, agajdosi@redhat.com, arout@redhat.com
             content-type: text
-            subject: Minishift nightly build ${BUILD_NUMBER}
-            body: "The build has finished. Build URL: ${BUILD_URL}"
+            subject: Minishift nightly build $BUILD_NUMBER
+            body: "The build has finished. Build URL: $BUILD_URL"
             failure: true
             success: true
     builders:


### PR DESCRIPTION
With single braces, JJB tries to format this as a template string. You can either drop them (like this) or use double-braces. Example: ${{BUILD_NUMBER}} 