### PR TITLE
Issue #39 Increase the timeout of minishift pr and master job

### DIFF
--- a/minishift-ci-index.yaml
+++ b/minishift-ci-index.yaml
@@ -297,7 +297,7 @@
           git_repo: minishift
           ci_project: '{name}'
           ci_cmd: '/bin/bash centos_ci.sh'
-          timeout: '60m'
+          timeout: '120m'
       - '{git_repo}':
           git_repo: minishift-centos-iso
           ci_project: '{name}'
@@ -313,7 +313,7 @@
           git_repo: minishift
           ci_project: '{name}'
           ci_cmd: '/bin/bash centos_ci.sh'
-          timeout: '60m'
+          timeout: '120m'
       - '{git_repo}-pr':
           git_repo: minishift-centos-iso
           ci_project: '{name}'


### PR DESCRIPTION
We had also timeout of 120m for nightly build.