### PR TITLE
Issue #75 Increase timeout for nightly job

### DIFF
--- a/minishift-ci-index.yaml
+++ b/minishift-ci-index.yaml
@@ -386,7 +386,7 @@
           ci_project: '{name}'
           ci_cmd: '/bin/bash centos_ci.sh'
           iso_url: 'centos'
-          timeout: '300m'
+          timeout: '390m'
           disable_publisher: false
       - '{git_repo}-nightly-{iso_url}':
           git_repo: minishift-addons


### PR DESCRIPTION
Increased the timeout by 1hr30mins. I have not done any special calculation for this, just increased by 1hr30mins to be on safer side for some more nightly/releases.  